### PR TITLE
Fixed problems with 32 bits architectures

### DIFF
--- a/kk_ihex_read.c
+++ b/kk_ihex_read.c
@@ -60,7 +60,7 @@ ihex_read_at_segment (struct ihex_state * const ihex, ihex_segment_t segment) {
 void
 ihex_end_read (struct ihex_state * const ihex) {
     uint_fast8_t type = ihex->flags & IHEX_READ_RECORD_TYPE_MASK;
-    uint_fast8_t sum;
+    uint8_t sum;
     if ((sum = ihex->length) == 0 && type == IHEX_DATA_RECORD) {
         return;
     }
@@ -147,7 +147,7 @@ ihex_read_byte (struct ihex_state * const ihex, const char byte) {
             if (b & ~IHEX_READ_RECORD_TYPE_MASK) {
                 // skip unknown record types silently
                 return;
-            } 
+            }
             ihex->flags = (ihex->flags & ~IHEX_READ_RECORD_TYPE_MASK) | b;
             break;
         case (READ_DATA_LOW >> 1):


### PR DESCRIPTION
Hi, i am working in a port of JerryScript with zephyr.
I would like to use your Intel Hex but i found a little bug that will break the checksum calculation on 32bits.

This is for the Arduino 101 which has a Quark processor with 32 bits architecture.

Details:

uint_fast8_t will be defined as a 32 bits integer therefore
sum = (~sum + 1U) ^ *eptr;
will fail to calculate the right value since *eptr will always be uint8_t

I would appreciate if you could accept this patch or fix the problem in some other way. 

Thanks!